### PR TITLE
feat: Change weight input format from decimal to integer

### DIFF
--- a/app/src/main/java/com/example/weighingscale/MainActivity.java
+++ b/app/src/main/java/com/example/weighingscale/MainActivity.java
@@ -199,7 +199,7 @@ public class MainActivity extends AppCompatActivity {
                         // Split the message if it contains multiple lines or transmissions
                         String[] messages = readMessage.split("\\r?\\n"); // Split by line breaks
                         for (String message : messages) {
-                            double weightValue = FormatterUtil.sanitizeAndConvertToDouble(message.trim());
+                            int weightValue = FormatterUtil.sanitizeAndConvertToInteger(message.trim());
                             sharedViewModel.setWeight(weightValue);
                         }
                         break;

--- a/app/src/main/java/com/example/weighingscale/data/dto/BatchDTO.java
+++ b/app/src/main/java/com/example/weighingscale/data/dto/BatchDTO.java
@@ -11,7 +11,7 @@ public class BatchDTO extends Batch {
     public String delivery_destination_province_name;
     public String delivery_destination_city_type;
     public String delivery_destination_city_name;
-    public double total_amount;
+    public int total_amount;
     public long total_price;
 
     // Constructor that calls the superclass constructor
@@ -20,7 +20,7 @@ public class BatchDTO extends Batch {
     }
 
     // Additional Getter Methods for the new fields if needed
-    public double getTotalAmount() {
+    public int getTotalAmount() {
         return total_amount;
     }
 

--- a/app/src/main/java/com/example/weighingscale/data/local/database/AppDatabase.java
+++ b/app/src/main/java/com/example/weighingscale/data/local/database/AppDatabase.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Executors;
             City.class,
             Province.class,
             Subdistrict.class
-        }, version = 1)
+        }, version = 2)
 @TypeConverters({Converters.class})
 public abstract class AppDatabase extends RoomDatabase {
     public abstract SettingDao settingDao();

--- a/app/src/main/java/com/example/weighingscale/data/model/BatchDetail.java
+++ b/app/src/main/java/com/example/weighingscale/data/model/BatchDetail.java
@@ -19,7 +19,7 @@ public class BatchDetail {
     public String id;
     public String batch_id;
     public Date datetime;
-    public Double amount;
+    public int amount;
 
     // Constructor
     public BatchDetail() {
@@ -35,7 +35,7 @@ public class BatchDetail {
         return datetime;
     }
 
-    public Double getAmount() {
+    public int getAmount() {
         return amount;
     }
 }

--- a/app/src/main/java/com/example/weighingscale/ui/history/HistoryAdapter.java
+++ b/app/src/main/java/com/example/weighingscale/ui/history/HistoryAdapter.java
@@ -56,7 +56,7 @@ public class HistoryAdapter extends ListAdapter<BatchDTO, HistoryAdapter.History
         BatchDTO currentData = getItem(position);
         holder.textViewTitle.setText(currentData.getTitle());
         holder.textViewDateTime.setText(DateTimeUtil.formatDateTime(currentData.start_date, "dd MMMM yyyy HH:mm"));
-        holder.textViewTotalWeight.setText(String.format("%.2f %s", currentData.getTotalAmount(), currentData.getUnit()));
+        holder.textViewTotalWeight.setText(String.format("%d %s", currentData.getTotalAmount(), currentData.getUnit()));
 
         holder.itemView.setBackgroundColor(selectedItems.contains(currentData.getID()) ?
                 holder.itemView.getResources().getColor(R.color.selectedItem) :

--- a/app/src/main/java/com/example/weighingscale/ui/history/HistoryDetailAdapter.java
+++ b/app/src/main/java/com/example/weighingscale/ui/history/HistoryDetailAdapter.java
@@ -61,7 +61,7 @@ public class HistoryDetailAdapter extends ListAdapter<BatchDetail, HistoryDetail
 
         public void bind(BatchDetail batchDetail, Batch currentBatch) {
             String formattedDate = DateTimeUtil.formatDateTime(batchDetail.getDatetime(), "dd/MM/yyyy HH:mm");
-            String amountText = String.format(Locale.getDefault(), "%.2f %s", batchDetail.getAmount(), currentBatch != null ? currentBatch.unit : "Kg");
+            String amountText = String.format(Locale.getDefault(), "%d %s", batchDetail.getAmount(), currentBatch != null ? currentBatch.unit : "Kg");
             binding.textViewWeight.setText(amountText);
             binding.textViewDate.setText(formattedDate);
         }

--- a/app/src/main/java/com/example/weighingscale/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/example/weighingscale/ui/home/HomeFragment.java
@@ -83,9 +83,9 @@ public class HomeFragment extends Fragment {
             public void onChanged(Integer status) {
                 if (status != null && status == StateConnecting.BLUETOOTH_CONNECTED) {
                     enable_auto_mode();
-                    sharedViewModel.getWeight().observe(getViewLifecycleOwner(), new Observer<Double>() {
+                    sharedViewModel.getWeight().observe(getViewLifecycleOwner(), new Observer<Integer>() {
                         @Override
-                        public void onChanged(Double weight) {
+                        public void onChanged(Integer weight) {
                             binding.textAmount.setText(String.valueOf(weight));
                         }
                     });
@@ -154,7 +154,7 @@ public class HomeFragment extends Fragment {
                             for (BatchDetail detail : data) {
                                 totalWeight += detail.getAmount();
                             }
-                            // String totalWeightText = String.format(Locale.getDefault(), "%.2f %s", totalWeight, currentSetting != null ? currentSetting.unit : "Kg");
+//                             String totalWeightText = String.format(Locale.getDefault(), "%.2f %s", totalWeight, currentSetting != null ? currentSetting.unit : "Kg");
                             String totalWeightText = WeighingUtils.convertWeight(totalWeight, currentSetting != null ? currentSetting.unit : "Kg");
                             binding.textTotalWeight.setText(totalWeightText);
 
@@ -198,7 +198,7 @@ public class HomeFragment extends Fragment {
                             binding.editAmount.getText().toString();
 
         try {
-            double amount = FormatterUtil.sanitizeAndConvertToDouble(amountText);
+            int amount = FormatterUtil.sanitizeAndConvertToInteger(amountText);
             if (amount <= 0) throw new NumberFormatException();
 
             homeViewModel.insertBatchDetail(currentBatchID, amount, currentSetting);
@@ -235,7 +235,7 @@ public class HomeFragment extends Fragment {
         builder.setView(dialogView)
                 .setTitle("Mengubah nilai log")
                 .setPositiveButton("Ubah", (dialog, id) -> {
-                    double amount = FormatterUtil.sanitizeAndConvertToDouble(etAmount.getText().toString());
+                    int amount = FormatterUtil.sanitizeAndConvertToInteger(etAmount.getText().toString());
                     if (amount <= 0) throw new NumberFormatException();
 
                     // Update Batch Detail

--- a/app/src/main/java/com/example/weighingscale/ui/home/HomeViewModel.java
+++ b/app/src/main/java/com/example/weighingscale/ui/home/HomeViewModel.java
@@ -41,7 +41,7 @@ public class HomeViewModel extends AndroidViewModel {
         batchRepository.insert(batch);
     }
 
-    public void insertBatchDetail(String batchId, double amount, Setting setting) {
+    public void insertBatchDetail(String batchId, int amount, Setting setting) {
         BatchDetail batchDetail = new BatchDetail();
         batchDetail.batch_id = batchId;
         batchDetail.datetime = new Date();

--- a/app/src/main/java/com/example/weighingscale/ui/home/LogAdapter.java
+++ b/app/src/main/java/com/example/weighingscale/ui/home/LogAdapter.java
@@ -62,7 +62,7 @@ public class LogAdapter extends ListAdapter<BatchDetail, LogAdapter.LogHolder> {
         String formattedDate = DateTimeUtil.formatDateTime(currentData.getDatetime(), "dd/MM/yyyy HH:mm");
 
         // Format the amount text including the unit
-        String amountText = String.format(Locale.getDefault(), "%.2f %s", currentData.getAmount(), currentSetting != null ? currentSetting.unit : "Kg");
+        String amountText = String.format(Locale.getDefault(), "%d %s", currentData.getAmount(), currentSetting != null ? currentSetting.unit : "Kg");
         holder.textViewWeight.setText(amountText);
         holder.textViewDate.setText(formattedDate);
 

--- a/app/src/main/java/com/example/weighingscale/ui/shared/SharedViewModel.java
+++ b/app/src/main/java/com/example/weighingscale/ui/shared/SharedViewModel.java
@@ -5,15 +5,15 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 public class SharedViewModel extends ViewModel {
-    private final MutableLiveData<Double> weight = new MutableLiveData<>();  // Changed from Integer to Double
+    private final MutableLiveData<Integer> weight = new MutableLiveData<>();
     private final MutableLiveData<Integer> bluetoothStatus = new MutableLiveData<>();
     private final MutableLiveData<Boolean> settingUpdated = new MutableLiveData<>();
 
-    public void setWeight(double weight) {  // Updated to double
+    public void setWeight(int weight) {
         this.weight.setValue(weight);
     }
 
-    public LiveData<Double> getWeight() {  // Updated return type
+    public LiveData<Integer> getWeight() {
         return weight;
     }
 

--- a/app/src/main/java/com/example/weighingscale/util/FormatterUtil.java
+++ b/app/src/main/java/com/example/weighingscale/util/FormatterUtil.java
@@ -8,6 +8,31 @@ import java.util.Objects;
 
 public class FormatterUtil {
 
+  /**
+     * Removes non-digit characters except the decimal point and converts the sanitized string to an integer.
+     * The result is floored to the nearest integer.
+     *
+     * @param input The input string to sanitize and convert.
+     * @return The floored integer value of the sanitized input.
+     * @throws NumberFormatException if the input cannot be converted to a valid number.
+     */
+    public static int sanitizeAndConvertToInteger(String input) throws NumberFormatException {
+       Log.d("log-scale", "Before : " + input);
+
+        // Remove non-digit characters except the decimal point
+        String sanitizedText = input.replaceAll("[^\\d.]", "");
+
+        // Check if the sanitized string is empty or only contains a decimal point
+        if (sanitizedText.isEmpty() || sanitizedText.equals(".")) {
+            throw new NumberFormatException("Invalid input: " + input);
+        }
+
+        Log.d("log-scale ", "After : " + (int) Math.floor(Double.parseDouble(sanitizedText)));
+
+        // Parse the sanitized string to double, then convert to integer by flooring
+        return (int) Math.floor(Double.parseDouble(sanitizedText));
+    }
+
     /**
      * Converts the sanitized input string to a double for precision.
      *

--- a/app/src/main/res/layout/dialog_input_log.xml
+++ b/app/src/main/res/layout/dialog_input_log.xml
@@ -36,7 +36,7 @@
                 android:id="@+id/et_amount"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="numberDecimal"/>
+                android:inputType="number"/>
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -109,7 +109,7 @@
             android:layout_height="wrap_content"
             android:autofillHints="0"
             android:hint="0"
-            android:inputType="numberDecimal"
+            android:inputType="number"
             android:textSize="64sp"
             android:layout_marginEnd="8dp"
             android:visibility="visible"


### PR DESCRIPTION
This commit modifies the input format for weight measurements in the Paradigm Scale application from decimal to integer. The decision to eliminate decimal points aligns with conventional practices among farmers, who typically focus on whole numbers during the harvest process.

By using integer values, the app enables quicker and more straightforward calculations, particularly in field environments where fast decision-making is crucial. This change enhances user experience by providing a more practical approach to weight measurement that reflects standard agricultural practices.